### PR TITLE
Add `aws-neuron-runtime-base` to list of yum packages in release notes

### DIFF
--- a/release-notes/dlami-release-notes.md
+++ b/release-notes/dlami-release-notes.md
@@ -41,6 +41,7 @@ sudo apt-get install tensorflow-model-server-neuron
 
 ###  Base and Conda DLAMI on Amazon Linux:
 ```bash
+sudo yum install aws-neuron-runtime-base
 sudo yum install aws-neuron-runtime
 sudo yum install aws-neuron-tools
 sudo yum install tensorflow-model-server-neuron


### PR DESCRIPTION
The release notes contain instructions for updating a DLAMI machine to
the latest version of the neuron software.  However, on Amazon Linux,
the instructions do not mention the `aws-neuron-runtime-base` package.
I found that running the `yum` commands as specified in the release
notes would upgrade the other neuron rpms, but not the `runtime-base`
one, even though there was a new version available.

I did not test this on Ubuntu, am not sure whether `apt` is smart
enough to recognize the dependency on `aws-neuron-runtime-base` and
update it as part of the execution of the commands mentioned in the
release notes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
