### PR TITLE
Neuron SDK Release - Jan 27, 2020

### DIFF
--- a/docs/guide-repo-config.md
+++ b/docs/guide-repo-config.md
@@ -92,6 +92,13 @@ pip install neuron-cc
 pip install mxnet-neuron
 ```
 
+### PyTorch
+
+```bash
+pip install neuron-cc[tensorflow]
+pip install torch-neuron
+```
+
 ## Conda
 
 ```bash
@@ -99,6 +106,7 @@ conda config --add channels https://conda.repos.neuron.amazonaws.com
 
 conda install mxnet-neuron
 conda install tensorflow-neuron
+conda install torch-neuron
 ```
 
 **Optional** To verify the packages before install (using tensorflow-neuron as an example):

--- a/docs/mxnet-neuron/tutorial-compile-infer.md
+++ b/docs/mxnet-neuron/tutorial-compile-infer.md
@@ -54,7 +54,7 @@ sudo yum install -y python3 gcc-c++
 ```bash
 python3 -m venv test_venv
 source test_venv/bin/activate
-pip install -U pip
+pip install -U pip==19.3.1
 ```
 2.3. Modify Pip repository configurations to point to the Neuron repository.
 ```bash

--- a/docs/neuron-tools/getting-started-tensorboard-neuron.md
+++ b/docs/neuron-tools/getting-started-tensorboard-neuron.md
@@ -2,7 +2,7 @@
 
 This guide is for developers who want to better understand how their model runs on Neuron Cores.
 
-TensorBoard-Neuron is adapted to provide useful information related to Neuron devices, such as compatibility and profiling.  It also preserves TensorBoard’s Debugger plugin, which may be useful in finding numerical mismatches.
+TensorBoard-Neuron is adapted to provide useful information related to Neuron devices, such as compatibility and profiling.  It also preserves TensorBoard’s existing features, including the Debugger plugin, which may be useful in finding numerical mismatches.
 
 ## Installation
 
@@ -23,6 +23,21 @@ Additionally, if you would like to profile your model (see below), you will also
 ```
 $ sudo apt install aws-neuron-tools
 ```
+
+Note: TensorBoard does not need to be installed to use TensorBoard-Neuron, and should be replaced with TensorBoard-Neuron if already installed.
+```
+$ pip uninstall tensorboard
+$ pip install tensorboard-neuron
+```
+
+OR
+
+```
+$ pip install tensorboard-neuron --force-reinstall
+```
+
+If TensorBoard-Neuron is not properly installed, the added functionalities for AWS Neuron may not work.
+For example, errors such as `tensorboard: error: unrecognized arguments: --run_neuron_profile` may occur when attempting to profile an inference.
 
 
 
@@ -46,7 +61,7 @@ NOTE: this directory must exist before you move on to the next step.  Otherwise,
 
 ## Visualizing data with TensorBoard-Neuron
 
-To view data in TensorBoard-Neuron, run the command below, where “logdir” is the directory where TensorFlow logs are generated.  (Note that this "logdir" is *not* the same as the NEURON_PROFILE directory that you set during inference, and in fact, depending on your configuration you may not have any tensorflow logs.  For this step, NEURON_PROFILE still needs to be set to the same directory you used during your inference run.  `tensorboard_neuron` will process the neuron profile data from this directory at startup.)
+To view data in TensorBoard-Neuron, run the command below, where “logdir” is the directory where TensorFlow logs are kept.  This logdir may or may not have any existing logs, or may not even exist yet.  AWS Neuron will populate this directory when using the `--run_neuron_profile` option.  (Note that this "logdir" is *not* the same as the NEURON_PROFILE directory that you set during inference, and in fact, depending on your configuration you may not have any tensorflow logs.  For this step, NEURON_PROFILE still needs to be set to the same directory you used during your inference run.  `tensorboard_neuron` will process the neuron profile data from the NEURON_PROFILE directory at startup.)
 
 ```
 $ tensorboard_neuron --logdir /path/to/logdir --run_neuron_profile

--- a/docs/pytorch-neuron/tutorial-compile-infer.md
+++ b/docs/pytorch-neuron/tutorial-compile-infer.md
@@ -174,9 +174,9 @@ from urllib import request
 from torchvision import models, transforms, datasets
 
 ## Create an image directory containing a small kitten
-os.makedirs("./images", exist_ok=True)
+os.makedirs("./torch_neuron_test/images", exist_ok=True)
 request.urlretrieve("https://raw.githubusercontent.com/awslabs/mxnet-model-server/master/docs/images/kitten_small.jpg",
-                    "./images/kitten_small.jpg")
+                    "./torch_neuron_test/images/kitten_small.jpg")
 
 
 ## Fetch labels to output the top classifications
@@ -193,7 +193,7 @@ normalize = transforms.Normalize(
     std=[0.229, 0.224, 0.225])
 
 eval_dataset = datasets.ImageFolder(
-    os.path.dirname("./"),
+    os.path.dirname("./torch_neuron_test/"),
     transforms.Compose([
     transforms.Resize([224, 224]),
     transforms.ToTensor(),

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -13,12 +13,18 @@ This structure is shown below, with each also linking to the release notes for t
 
   + #### [Tensorflow-Neuron Release Notes](./tensorflow-neuron.md)
   + #### [Neuron-CC Release Notes](./neuron-cc.md)
-  + #### [TensorBoard-neuron Release Notes](./tensorboard-neuron.md)
+  + #### [TensorBoard-Neuron Release Notes](./tensorboard-neuron.md)
 
 + ### [Conda MXNet Release Notes](./conda/conda-mxnet-neuron.md)
 
-  + #### [MXNet-neuron Release Notes](./mxnet-neuron.md)
+  + #### [MXNet-Neuron Release Notes](./mxnet-neuron.md)
   + #### [Neuron-CC Release Notes](./neuron-cc.md)
+  
++ ### [Conda Torch Release Notes](./conda/conda-torch-neuron.md)
+
+  + #### [Torch-Neuron Release Notes](./torch-neuron.md)
+  + #### [Neuron-CC Release Notes](./neuron-cc.md)
+
 
 + ### [Tensorflow-Model-Server-Neuron Release Notes](./tensorflow-modelserver-neuron.md)
 + ### [Neuron-Runtime Release Notes](./neuron-runtime.md)
@@ -31,7 +37,7 @@ This structure is shown below, with each also linking to the release notes for t
 ## [MXNet-Neuron Release Notes](./mxnet-neuron.md)
 ## [Tensorflow-Neuron Release Notes](./tensorflow-neuron.md)
 ## [Tensorboard-Neuron Release Notes](./tensorboard-neuron.md)
-## [Torch Neuron Release Notes](./torch-neuron.md)
+## [Torch-Neuron Release Notes](./torch-neuron.md)
 
 ## Important to know: 
 1. Size of neural network. The current Neuron compiler release has a limitation in terms of the size of neural network it could effectively optimize for. The size of neural network is influenced by a number of factors including: a) type of neural network (CNN, LSTM, MLP) , b) number of layers, c) sizes of input (dimension of the tensors, batch size, ...). As a result, we limit the sizes of CNN models like ResNet to have an input size limit of 480x480 fp/bf16, batch size=4; LSTM models like GNMT to have a time step limit of 900; MLP models like BERT to have input size limit of sequence length=128, batch=8.

--- a/release-notes/conda/conda-mxnet-neuron.md
+++ b/release-notes/conda/conda-mxnet-neuron.md
@@ -2,6 +2,17 @@
 
 This document lists the release notes for the Neuron Conda-MxNet package.
 
+# [1.5.1.1.0.1401.0_1.0.737.0]
+
+Date 1/27/2020
+
+## Included Neuron Packages
+
+neuron-cc-1.0.6801.0
+
+mxnet-neuron-1.5.1.1.0.1401.0
+
+
 # [1.5.1.1.0.1349.0_1.0.611.0]
 
 Date 12/20/2019

--- a/release-notes/conda/conda-tensorflow-neuron.md
+++ b/release-notes/conda/conda-tensorflow-neuron.md
@@ -2,6 +2,19 @@
 
 This document lists the release notes for the Neuron Conda-TensorFlow package.
 
+# [1.15.0.1.0.997.0_1.0.733.0]
+
+Date 1/27/2020
+
+## Included Neuron Packages
+
+neuron-cc-1.0.6801.0
+
+tensorflow-neuron-1.15.0.1.0.997.0
+
+tensorboard-neuron-1.15.0.1.0.315.0
+
+
 # [1.15.0.1.0.803.0_1.0.611.0]
 
 Date 12/20/2019

--- a/release-notes/conda/conda-torch-neuron.md
+++ b/release-notes/conda/conda-torch-neuron.md
@@ -1,0 +1,21 @@
+# Conda PyTorch Release notes
+
+This document lists the release notes for the Neuron Conda-Pytorch package.
+
+### [Conda Tensorflow Release Notes](../tensorflow-neuron.md)
+
+# [1.3.0.1.0.41.0_1.0.737.0]
+
+Date: 1/27/2020
+
+This version is only available from the release DLAMI v26.0. Please update to latest version.
+
+## Included Neuron Packages
+
+[neuron-cc-1.0.6801.0](../neuron-cc.md#1068010)
+
+[torch-neuron-1.0.672.0](../torch-neuron.md#106720)
+
+torch-neuron-base-1.3.0.1.0.41.0
+
+## Known Issues and Limitations

--- a/release-notes/mxnet-neuron.md
+++ b/release-notes/mxnet-neuron.md
@@ -2,6 +2,56 @@
 
 This document lists the release notes for MXNet-Neuron framework.
 
+# [1.5.1.1.0.1401.0]
+
+Date 1/27/2020
+
+## Summary
+
+No major changes or fixes. 
+
+## Major New Features
+
+## Resolved Issues
+
+## Known Issues and Limitations
+
+* Latest pip version 20.0.1 breaks installation of MXNet-Neuron pip wheel which has py2.py3 in the wheel name. This breaks all existing released versions. The Error looks like: 
+
+```
+Looking in indexes: https://pypi.org/simple, https://pip.repos.neuron.amazonaws.com
+ERROR: Could not find a version that satisfies the requirement mxnet-neuron (from versions: none)
+ERROR: No matching distribution found for mxnet-neuron
+```
+   * Work around:  install the older version of pip using "pip install pip==19.3.1".
+ 
+ * Issue: MXNet Model Server is not able to clean up Neuron RTD states after model is unloaded (deleted) from model server and previous workaround "`/opt/aws/neuron/bin/neuron-cli reset`" is unable to clear all Neuron RTD states.
+   * Workaround: run “`sudo systemctl restart neuron-rtd`“ to clear Neuron RTD states after all models are unloaded and server is shut down.
+ 
+
+## Other Notes
+
+# [1.5.1.1.0.1325.0]
+
+Date 12/1/2019
+
+## Summary
+
+## Major New Features
+
+## Resolved Issues
+
+* Issue: Compiler flags cannot be passed to compiler during compile call. The fix: compiler flags can be passed to compiler during compile call using “flags” option followed by a list of flags.
+
+* Issue: Advanced CPU fallback option is a way to attempt to improve the number of operators on Inferentia. The default is currently set to on, which may cause failures. The fix: This option is now off by default.
+
+## Known Issues and Limitations
+
+* Issue: MXNet Model Server is not able to clean up Neuron RTD states after model is unloaded (deleted) from model server and previous workaround "`/opt/aws/neuron/bin/neuron-cli reset`" is unable to clear all Neuron RTD states.
+  * Workaround: run “`sudo systemctl restart neuron-rtd`“ to clear Neuron RTD states after all models are unloaded and server is shut down.
+  
+## Other Notes
+
 # [1.5.1.1.0.1349.0]
 
 Date 12/20/2019

--- a/release-notes/neuron-cc-ops/neuron-cc-ops-mxnet.md
+++ b/release-notes/neuron-cc-ops/neuron-cc-ops-mxnet.md
@@ -1,5 +1,13 @@
 # Supported operators [MXNet]
 
+### Neuron Compiler Release [1.0.6801]
+
+No changes
+
+### Neuron Compiler Release [1.0.5939]
+
+no changes
+
 ### Neuron Compiler Release [1.0.5301]
 
 no changes

--- a/release-notes/neuron-cc-ops/neuron-cc-ops-onnx.md
+++ b/release-notes/neuron-cc-ops/neuron-cc-ops-onnx.md
@@ -1,5 +1,12 @@
 # Supported operators [ONNX]
 
+### Neuron Compiler Release [1.0.6801]
+
+Added support for the following operators:
+```
+Abs
+```
+
 ### Neuron Compiler Release [1.0.5301]
 
 no changes

--- a/release-notes/neuron-cc-ops/neuron-cc-ops-pytorch.md
+++ b/release-notes/neuron-cc-ops/neuron-cc-ops-pytorch.md
@@ -4,31 +4,40 @@ Current operator lists may be generated with these commands inside python:
 
 ```python
 import torch.neuron
-print(torch.neuron.get_supported_operations())
+print(*torch.neuron.get_supported_operations(), sep='\n')
 ```
+
+### PyTorch Neuron Release [1.0.672.0]
+No change
 
 ### PyTorch Neuron Release [1.0.552.0]
 
 ```
-_convolution
-adaptive_avg_pool2d
-add
-add_
-addmm
-avg_pool2d
-batch_norm
-cat
-dimension_value
-dropout
-flatten
-max_pool2d
-mul
-relu_
-t
-tanh
-tf_broadcastable_slice
-tf_padding
-values
+aten::_convolution
+aten::adaptive_avg_pool2d
+aten::add
+aten::add_
+aten::addmm
+aten::avg_pool2d
+aten::batch_norm
+aten::cat
+aten::dimension_value
+aten::dropout
+aten::flatten
+aten::max_pool2d
+aten::mul
+aten::relu_
+aten::t
+aten::tanh
+aten::tf_broadcastable_slice
+aten::tf_padding
+aten::values
+prim::Constant
+prim::GetAttr
+prim::ListConstruct
+prim::ListUnpack
+prim::TupleConstruct
+prim::TupleUnpack
 ```
 
 

--- a/release-notes/neuron-cc-ops/neuron-cc-ops-tensorflow.md
+++ b/release-notes/neuron-cc-ops/neuron-cc-ops-tensorflow.md
@@ -1,8 +1,17 @@
 # Supported operators [TensorFlow]
 
+
+### Neuron Compiler Release [1.0.6801]
+
+No changes
+
+### Neuron Compiler Release [1.0.5939]
+
+No changes
+
 ### Neuron Compiler Release [1.0.5301]
 
-no changes
+No changes
 
 ### Neuron Compiler Release [1.0.4680.0]
 

--- a/release-notes/neuron-cc.md
+++ b/release-notes/neuron-cc.md
@@ -1,18 +1,60 @@
 # Neuron Compiler Release Notes
 
-This document lists the release notes for AWS Neuron compiler. The neuron compiler is an ahead-of-time compiler that ensures Neuron will optimally utilize the Inferentia devices.
+This document lists the release notes for AWS Neuron compiler. The Neuron Compiler is an ahead-of-time compiler that ensures Neuron will optimally utilize the Inferentia chips.
 
-Operator-support for each input format is provided directly from the compiler:
+Operator-support for each input format is provided directly from the compiler. By default, the operators _supported_ by inferentia are listed. For a list that includes runtime-CPU executed operators, use '--list all'
 
 ```
-neuron-cc --list-operators --framwork {TENSORFLOW | MXNET | ONNX}
+neuron-cc list-operators --framework {TENSORFLOW | MXNET | ONNX} [--list {all|supported}]
 ```
 
-The supported operators are also listed here:
+```
+Please use "pip install --upgrade neuron-cc" to update the package
+```
 
-* [Neuron-cc Tensorflow Operators](./neuron-cc-ops/neuron-cc-ops-tensorflow.md)
-* [Neuron-cc MXNet Operators](./neuron-cc-ops/neuron-cc-ops-mxnet.md)
-* [Neuron-cc ONNX Operators](./neuron-cc-ops/neuron-cc-ops-onnx.md)
+# [1.0.6801.0]
+
+Date 1/27/2020
+
+## Summary
+
+Bug fixes and some performance enhancement related to data movement for BERT-type neural networks.
+
+## Major New Features
+
+None
+
+## Resolved Issues
+
+* Improved throughput for operators processed in the Neuron Runtime CPU. As an example: execution of 4 single NeuronCore NEFF models of resnet50 v2 float16 batch = 5 in parallel on an inf1.1xlarge sped up by 30%.
+* Corrected shape handling in Gather(TensorFlow)/Take(MXNet) operators that are processed by the Neuron Runtime in the Neuron Runtime vCPU, which resolves a possible crash in Neuron Compiler when compiling models with these operators with some shapes.
+* Added support for Tensorflow *OneHot* operator (as a Neuron Runtime CPU operator).
+* Added more internal checking for compiler correctness with newly defined error messages for this case.
+```
+      “Internal ERROR: Data race between Op1 'Name1(...) [...]' and Op2 'Name2(...) [...]'”
+```
+* Fixed out-of-memory issue introduced in 1.0.5939.0 such that some large models (BERT) compiled on instances with insufficient host memory would cause the runtime to crash with an invalid NEFF. This is actually a compiler error, but due to addtional script layers wrappering this in the [BERT demo](../src/examples/tensorflow/bert_demo/README.md), this would have likely been seen as a runtime error like this:
+
+```bash
+2020-01-09 13:40:26.002594: E tensorflow/core/framework/op_segment.cc:54] Create kernel failed: Invalid argument: neff is invalid
+2020-01-09 13:40:26.002637: E tensorflow/core/common_runtime/executor.cc:642] Executor failed to create kernel. Invalid argument: neff is invalid
+[[{{node bert/NeuronOp}}]]
+```
+
+## Known issues and limitations
+
+See previous releases. Some tutorials show use of specific compiler options and flags, these are needed to help provide guidance to the compiler to acheive best performance in specific cases. Please do not use in cases other than as shown in the specific tutorial as results may not be defined. These options should be considered experimental and will be removed over time. 
+
+## Other Notes
+
+### Dependencies
+```
+dmlc_nnvm-1.0.1619.0
+dmlc_topi-1.0.1619.0
+dmlc_tvm-1.0.1619.0
+inferentia_hwm-1.0.839.0
+islpy-2018.2
+```
 
 # [1.0.5939.0]
 

--- a/release-notes/neuron-runtime.md
+++ b/release-notes/neuron-runtime.md
@@ -2,6 +2,36 @@
 
 This document lists the current release notes for AWS Neuron Runtime.  Neuron Runtime software manages runtime aspects of executing inferences on Inferentia chips. It runs on Ubuntu(16/18) and Amazon Linux 2.
 
+# [1.0.5236.0]
+
+Date: 1/27/2020
+
+## Major New Features
+
+N/A
+
+## Improvements
+
+* Improved neuron-rtd startup time on inf1.6xl and inf1.24xl.  Neuron-rtd startup now takes the same amount of time on all instance sizes. 
+* Improved inference latency for Neural Networks that fully execute on Inferentia (have no on-CPU nodes).  The exact latency improvement is network dependent and is estimated to be 50-100us per inference. 
+* Neural Network load GRPC returns descriptive error message when the load fails.
+* Changed default behavior of neuron-rtd to drop elevated privileges after runtime initialization.  During initialization elevated priveleges are necessary to allow bus enumeration and shared memory with frameworks.
+* Error log is automatically displayed on the console if the installation of aws-neuron-runtime fails.
+
+## Resolved Issues
+
+* minor bug fixes
+
+## Known Issues and Limitations
+
+* A model might fail to load due to insufficient number of huge memory pages made available to Neuron-RTD. A manual reconfiguration and Neuron-RTD restart is required for increasing the amount of huge memory pages available to Neuron-RTD.
+    * Workaround: manually increase the amount of huge memory pages available to Neuron runtime by following the [instructions here.](https://github.com/aws/aws-neuron-sdk/blob/master/docs/neuron-runtime/nrt_start.md#step-3-configure-nr_hugepages) (Requires a restart of the runtime daemon and a possible change to system-wide configs.)
+* Neuron-RTD does not return verbose error messages when an inference fails. Detailed error messages are only available in syslog.
+    * Workaround: manually search syslog file for Neuron-RTD error messages.
+
+
+
+
 # [1.0.4751.0]
 
 Date: 12/20/2019

--- a/release-notes/neuron-tools.md
+++ b/release-notes/neuron-tools.md
@@ -2,6 +2,31 @@
 
 This documents lists the release notes for AWS Neuron tools. Neuron tools are used for debugging, profiling and gathering inferentia system information.
 
+
+# [1.0.5165.0]
+
+Date: 1/27/2020
+
+## Summary
+
+Improved neuron-top load time, especially when a large amount of models are loaded.
+
+## Major New Features
+
+N/A
+
+## Resolved Issues
+
+N/A
+
+## Known Issues and Limitations
+
+* neuron-top consumes one vCPU to monitor hardware resources, which might affect performance of the system on inf1.xlarge.  Using a larger instance size will not have the same limitation.  In a future release we will improve this for smaller instance sizes.
+
+## Other Notes
+
+
+
 # [1.0.4587.0]
 
 Date: 12/20/2019

--- a/release-notes/tensorflow-modelserver-neuron.md
+++ b/release-notes/tensorflow-modelserver-neuron.md
@@ -2,21 +2,24 @@
 
 This document lists the release notes for the TensorFlow-Model-Server-Neuron package.
 
+
+# [1.15.0.1.0.997.0]
+
+Date 1/27/2019
+
+## Summary
+
+No change.  See [TensorFlow-Neuron Release Notes](./tensorflow-neuron.md) for related TensorFlow-Neuron release notes.
+ 
+
 # [1.15.0.1.0.803.0]
 
 Date 12/20/2019
 
 ## Summary
 
-See [TensorFlow-Neuron Release Notes](./tensorflow-neuron.md)
+No change.  See [TensorFlow-Neuron Release Notes](./tensorflow-neuron.md) for related TensorFlow-Neuron release notes.
 
-## Major New Features
-
-## Resolved Issues
-
-## Known Issues and Limitations
-
-## Other Notes
 
 # [1.15.0.1.0.749.0]
 
@@ -24,15 +27,8 @@ Date 12/1/2019
 
 ## Summary
 
-See [TensorFlow-Neuron Release Notes](./tensorflow-neuron.md)
+No change.  See [TensorFlow-Neuron Release Notes](./tensorflow-neuron.md) for related TensorFlow-Neuron release notes.
 
-## Major New Features
-
-## Resolved Issues
-
-## Known Issues and Limitations
-
-## Other Notes
 
 # [1.15.0.1.0.663.0]
 
@@ -41,11 +37,3 @@ Date 11/29/2019
 ## Summary
 
 This version is available only in released DLAMI v26.0. See TensorFlow-Neuron Release Notes. Please [update](./dlami-release-notes.md#known-issues) to latest version.
-
-## Major New Features
-
-## Resolved Issues
-
-## Known Issues and Limitations
-
-## Other Notes

--- a/release-notes/tensorflow-neuron.md
+++ b/release-notes/tensorflow-neuron.md
@@ -2,6 +2,32 @@
 
 This document lists the release notes for the TensorFlow-Neuron package.
 
+# [1.15.0.1.0.997.0]
+
+Date: 1/27/2020
+
+## Summary
+
+## Major New Features
+
+* Added support for NCHW pooling operators in tfn.saved_model.compile.
+
+## Resolved Issues
+
+* Fixed GRPC transient status error issue.
+* Fixed a graph partitioner issue with control inputs.
+
+## Known Issues and Limitations
+* Issue: When compiling a large model, may encounter.  
+```
+terminate called after throwing an instance of 'std::bad_alloc'
+```
+Solution: run compilation on c5.4xlarge instance type or larger.
+
+## Other Notes
+
+
+
 # [1.15.0.1.0.803.0]
 
 Date: 12/20/2019

--- a/release-notes/torch-neuron.md
+++ b/release-notes/torch-neuron.md
@@ -1,5 +1,22 @@
 # PyTorch Neuron release notes
 
+# [1.0.672.0]
+
+Date: 1/27/2020
+
+## Summary
+
+## Major new features
+
+## Resolved issues
+
+* Python 3.5 and Python 3.7 are now supported.
+
+## Known issues and limitations
+
+## Other Notes
+
+
 # [1.0.627.0]
 
 Date: 12/20/2019


### PR DESCRIPTION
*Description of changes:*
Updated release notes and documentation for the Jan 27, 2020 release of Neuron SDK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
