### PR TITLE
Update docs to stipulate pinning to torchvision 0.4.2 (#83)

### DIFF
--- a/docs/pytorch-neuron/tutorial-compile-infer.md
+++ b/docs/pytorch-neuron/tutorial-compile-infer.md
@@ -85,7 +85,7 @@ pip install neuron-cc[tensorflow]
 pip install pillow==6.2.2
 
 # We use the --no-deps here to prevent torchvision installing standard torch
-pip install torchvision --no-deps
+pip install torchvision==0.4.2 --no-deps
 ```
 
 ## Step 3: Compile on compilation instance

--- a/docs/pytorch-neuron/tutorial-manual-partitioning.md
+++ b/docs/pytorch-neuron/tutorial-manual-partitioning.md
@@ -54,7 +54,7 @@ conda activate my_notebook_env
 pip install torch-neuron --extra-index-url=https://pip.repos.neuron.amazonaws.com
 pip install neuron-cc[tensorflow] --extra-index-url=https://pip.repos.neuron.amazonaws.com
 pip install pillow==6.2.2
-pip install torchvision --no-deps
+pip install torchvision==0.4.2 --no-deps
 pip install jupyter
 
 mkdir -p notebook_tutorial
@@ -66,7 +66,7 @@ cd notebook_tutorial
 Run the following command to fetch the notebook into the current directory:
 
 ```bash
-curl -O https://github.com/aws/aws-neuron-sdk/blob/master/src/pytorch/resnet50_partition.ipynb
+curl -O https://raw.githubusercontent.com/aws/aws-neuron-sdk/master/src/pytorch/resnet50_partition.ipynb
 ```
 
 
@@ -121,3 +121,17 @@ Kernel → Change Kernel → Environment (conda_my_notebook_env)
 ## Step 7: Terminate your instance
 
 When done, don't forget to terminate your instance through the AWS console to avoid ongoing charges
+
+## Troubleshooting
+
+If your jupyter notebook does not start please try the following:
+
+```
+mv ~/.jupyter ~/.jupyter.old
+mkdir -p ~/.jupyter
+echo "c.NotebookApp.iopub_data_rate_limit = 10000000000" > ~/.jupyter/jupyter_notebook_config.py
+
+conda install nb_conda_kernels
+
+jupyter notebook
+```


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-neuron-sdk/issues/83

*Description of changes:*

* Update docs to stipulate pinning to torchvision 0.4.2

* Fix errors on notebook download URL.  Add troubleshooting


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
