### PR TITLE
Apply device plugin only to INF1 nodes

### DIFF
--- a/docs/neuron-container-tools/k8s-neuron-device-plugin.yml
+++ b/docs/neuron-container-tools/k8s-neuron-device-plugin.yml
@@ -18,18 +18,38 @@ spec:
         name: neuron-device-plugin-ds
     spec:
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - key: aws.amazon.com/neuron
-          operator: Exists
-          effect: NoSchedule
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: aws.amazon.com/neuron
+        operator: Exists
+        effect: NoSchedule
       # Mark this pod as a critical add-on; when enabled, the critical add-on
       # scheduler reserves resources for critical add-on pods so that they can
       # be rescheduled after a failure.
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       priorityClassName: "system-node-critical"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "beta.kubernetes.io/instance-type"
+                    operator: In
+                    values:
+                      - inf1.xlarge
+                      - inf1.2xlarge
+                      - inf1.6xlarge
+                      - inf1.4xlarge
+              - matchExpressions:
+                  - key: "node.kubernetes.io/instance-type"
+                    operator: In
+                    values:
+                      - inf1.xlarge
+                      - inf1.2xlarge
+                      - inf1.6xlarge
+                      - inf1.24xlarge
       containers:
-        - image: 790709498068.dkr.ecr.us-east-1.amazonaws.com/neuron-device-plugin:latest
+        - image: 790709498068.dkr.ecr.us-west-2.amazonaws.com/neuron-device-plugin:1.0.9043.0
           imagePullPolicy: Always
           name: k8s-neuron-device-plugin-ctr
           securityContext:
@@ -43,3 +63,4 @@ spec:
         - name: device-plugin
           hostPath:
             path: /var/lib/kubelet/device-plugins
+


### PR DESCRIPTION
This is especially important when working with hetero k8 clusters.

Co-authored-by: Alexander Nageswaran <awaran@amazon.com>



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
