### PR TITLE
mrpc_adapt.sh: ValueError: ['--model_type', 'bert', '--do_lower_case']

### DIFF
--- a/src/examples/pytorch/bert_tutorial/mrpc_adapt.sh
+++ b/src/examples/pytorch/bert_tutorial/mrpc_adapt.sh
@@ -35,12 +35,10 @@ pushd .
 cd $TRANSFORMER_DIR
 
 python -m torch.distributed.launch --nproc_per_node 8 ./examples/text-classification/run_glue.py   \
-    --model_type bert \
     --model_name_or_path bert-large-uncased-whole-word-masking \
     --task_name MRPC \
     --do_train   \
     --do_eval   \
-    --do_lower_case   \
     --data_dir $GLUE_DIR/MRPC/   \
     --max_seq_length 128   \
     --per_gpu_eval_batch_size=8   \


### PR DESCRIPTION
Stage 1, step 3 in the [tutorial](https://github.com/aws/aws-neuron-sdk/blob/master/src/examples/pytorch/bert_tutorial/bert_large_mrpc_tutorial.md) fails at ```. ./setup.sh $S3_BUCKET_PREFIX && . ./mrpc_adapt.sh``` due to the following error:

```
ValueError: Some specified arguments are not used by the HfArgumentParser: ['--model_type', 'bert', '--do_lower_case']
```

- Removed arguments for --model_type and --do_lower_case when running ```python -m torch.distributed.launch```
- Ref: https://github.com/huggingface/transformers/commit/f84dcd02195a890bb4a09fb97f5d7cb81fefa963#diff-af35b1d4b7bef3f94586747668b55562

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
