### PR TITLE
ECR login doc fix

### DIFF
--- a/docs/neuron-container-tools/docker-example/README.md
+++ b/docs/neuron-container-tools/docker-example/README.md
@@ -16,7 +16,7 @@ Run neuron-rtd container as shown below. A volume must be mounted to :/sock wher
 open a UDS socket. The application can interact with runtime using this socket.
 
 ```bash
-$(aws ecr get-login --no-include-email --region us-east-1 --registry-ids 790709498068)
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 790709498068.dkr.ecr.us-east-1.amazonaws.com
 docker pull 790709498068.dkr.ecr.us-east-1.amazonaws.com/neuron-rtd:latest
 docker tag 790709498068.dkr.ecr.us-east-1.amazonaws.com/neuron-rtd:latest neuron-rtd
 mkdir /tmp/neuron_rtd_sock

--- a/release-notes/neuron-k8.md
+++ b/release-notes/neuron-k8.md
@@ -11,6 +11,13 @@ aws ecr list-images --registry-id 790709498068 --repository-name  neuron-device-
 aws ecr list-images --registry-id 790709498068 --repository-name  neuron-scheduler --region us-west-2
 ```
 
+To Pull the Images from ECR:
+```
+aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 790709498068.dkr.ecr.us-west-2.amazonaws.com
+docker pull  790709498068.dkr.ecr.us-west-2.amazonaws.com/neuron-device-plugin
+docker pull  790709498068.dkr.ecr.us-west-2.amazonaws.com/neuron-scheduler
+```
+
 
 # [1.0.11000.0]
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-neuron-sdk/issues/159

*Description of changes:*
* Updating ECR documentation for image pull credentials.  
* Dropping ecr get-login from documentation since its deprecated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
