### PR TITLE
Only use transformer versions less than 4.0

### DIFF
--- a/src/examples/pytorch/bert_tutorial/tutorial_pretrained_bert.ipynb
+++ b/src/examples/pytorch/bert_tutorial/tutorial_pretrained_bert.ipynb
@@ -8,9 +8,10 @@
     "Starting from `torch-neuron==1.0.1386.0`, the AWS Neuron PyTorch compilation API `torch.neuron.trace` supports assigning unsupported `aten` operators to run on CPU. Here we demonstrate its example usage on HuggingFace's BERT-base.\n",
     "\n",
     "### Install dependencies\n",
-    "This tutorial depends on `torch-neuron>=1.0.1386.0`, `neuron-cc>=1.0.16861.0`, and HuggingFace's `transformers` package. You may install them with `pip`.\n",
+    "This tutorial depends on `torch-neuron>=1.0.1386.0`, `neuron-cc>=1.0.16861.0`, and HuggingFace's `transformers` package (<4.0). You may install them with `pip`.\n",
     "```bash\n",
-    "python3 -m pip install torch-neuron neuron-cc[tensorflow] transformers --upgrade --extra-index-url=https://pip.repos.neuron.amazonaws.com\n",
+    "!python3 -m pip install -U \"transformers<4.0\"\n",
+    "python3 -m pip install torch-neuron neuron-cc[tensorflow] --upgrade --extra-index-url=https://pip.repos.neuron.amazonaws.com\n",
     "```\n",
     "For simplicity, it is recommended to do a one-stop setup of all these dependencies on an inf1 instance. However, do note that our compiler can cross-compile for inf1 on a CPU-only machine, and so you may try the compilation step on your existing EC2 instance, or a local machine running Linux."
    ]

--- a/src/examples/pytorch/bert_tutorial/tutorial_pretrained_bert.ipynb
+++ b/src/examples/pytorch/bert_tutorial/tutorial_pretrained_bert.ipynb
@@ -10,7 +10,7 @@
     "### Install dependencies\n",
     "This tutorial depends on `torch-neuron>=1.0.1386.0`, `neuron-cc>=1.0.16861.0`, and HuggingFace's `transformers` package (<4.0). You may install them with `pip`.\n",
     "```bash\n",
-    "!python3 -m pip install -U \"transformers<4.0\"\n",
+    "python3 -m pip install \"transformers<4.0\"\n",
     "python3 -m pip install torch-neuron neuron-cc[tensorflow] --upgrade --extra-index-url=https://pip.repos.neuron.amazonaws.com\n",
     "```\n",
     "For simplicity, it is recommended to do a one-stop setup of all these dependencies on an inf1 instance. However, do note that our compiler can cross-compile for inf1 on a CPU-only machine, and so you may try the compilation step on your existing EC2 instance, or a local machine running Linux."


### PR DESCRIPTION
Fixes an unpinned dependency on transformers (needs to be < 4.0)