### PR TITLE
Stopping support for python 3.5

### DIFF
--- a/docs-rtd/release-notes/README.rst
+++ b/docs-rtd/release-notes/README.rst
@@ -12,7 +12,9 @@ Important to know:
 ------------------
 
 1. This update continues to support the torch-neuron version of PyTorch 1.5.1 for backwards compatibility.
-
+2. As Python 3.5 reached end-of-life in October 2020, and many packages including TorchVision and Transformers have
+stopped support for Python 3.5, we will begin to stop supporting Python 3.5 for frameworks, starting with
+PyTorch-Neuron version :ref:`neuron-torch-11170` in this release. You can continue to use older versions with Python 3.5.
 
 November 17, 2020 Release
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs-rtd/release-notes/torch-neuron/torch-neuron.rst
+++ b/docs-rtd/release-notes/torch-neuron/torch-neuron.rst
@@ -35,9 +35,10 @@ you can successfully torch.neuron.trace
    NotImplementedError during compilation
 -  There is a dependency between versions of torchvision and the torch package that customers should be aware of when compiling torchvision models.  These dependency rules can be managed through pip.  At the time of writing torchvision==0.6.1 matched the torch==1.5.1 release, and torchvision==0.8.2 mathced the torch==1.7.1 release
 
+.. _neuron-torch-11170:
 
 [1.1.7.0]
-^^^^^^^^^^^^
+^^^^^^^^^
 
 Date: 12/23/2020
 


### PR DESCRIPTION
Add generic note about stopping support for python 3.5

Co-authored-by: Michael J. Wade <micwade@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
