### PR TITLE
Added work_dir as an optional kwarg

### DIFF
--- a/neuron-guide/neuron-frameworks/mxnet-neuron/api-compilation-python-api.rst
+++ b/neuron-guide/neuron-frameworks/mxnet-neuron/api-compilation-python-api.rst
@@ -57,7 +57,8 @@ Arguments
    -  Advanced option to exclude node names:
       ``compile_args={'excl_node_names' : [<node names>]}`` where is a
       comma separated list of node name strings.
-
+   -  work_dir:  relative or absolute path for storing params and jsons generated 
+      during compilation when SUBGRAPH_INFO=1.
 Returns
 -------
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added documentation for work_dir, which can be a relative or absolute path used for storing params and jsons generated during compilation when SUBGRAPH_INFO=1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
