### PR TITLE
typo: version number of aws-neuron-runtime

### DIFF
--- a/release-notes/neuron-runtime.rst
+++ b/release-notes/neuron-runtime.rst
@@ -32,9 +32,9 @@ NEFF Version Runtime Version Range Notes
 
 --------------
 
-.. _15100:
+.. _15000:
 
-[1.5.1.0]
+[1.5.0.0]
 =========
 
 Date: 05/28/2021


### PR DESCRIPTION
*Description of changes:*
Fixes the version number from 1.5.1.0 to 1.5.0.0 to match the neuron-rtd version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
