### PR TITLE
Fix fast-math none option

### DIFF
--- a/neuron-guide/neuron-cc/command-line-reference.rst
+++ b/neuron-guide/neuron-cc/command-line-reference.rst
@@ -169,7 +169,7 @@ Available Commands:
 
             * ``all`` is equivalent to using ``fp32-cast-all fast-relayout`` (best performance)
 
-            * ``none`` is equivalent to using ``fp32-cast-matmult-fp16 no-fast-relayout`` (best accuracy)
+            * ``none`` is equivalent to using ``fp32-cast-matmult-bf16 no-fast-relayout`` (best accuracy)
 
             * ``fp32-cast-*`` options are mutually exclusive
 


### PR DESCRIPTION
*Description of changes:*
fast-math none is equivalent to using fp32-cast-matmult-bf16 and not fp32-cast-matmult-fp16

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
